### PR TITLE
Add support for new theme

### DIFF
--- a/byttm.css
+++ b/byttm.css
@@ -1,14 +1,17 @@
-ytd-watch-flexy[theater] #player-full-bleed-container.ytd-watch-flexy {
+ytd-watch-flexy[theater] #player-full-bleed-container.ytd-watch-flexy,
+ytd-watch-grid[theater] #player-full-bleed-container.ytd-watch-grid {
   height: 100vh !important;
   max-height: calc(100vh - 56px) !important;
 }
 
-ytd-watch-flexy[fullscreen] #player-full-bleed-container.ytd-watch-flexy {
+ytd-watch-flexy[fullscreen] #player-full-bleed-container.ytd-watch-flexy,
+ytd-watch-grid[fullscreen] #player-full-bleed-container.ytd-watch-grid {
   max-height: 100vh !important;
   min-height: 100vh !important;
 }
 
-ytd-watch-flexy[full-bleed-player] #full-bleed-container.ytd-watch-flexy {
+ytd-watch-flexy[full-bleed-player] #full-bleed-container.ytd-watch-flexy,
+ytd-watch-grid[full-bleed-player] #full-bleed-container.ytd-watch-grid {
   block-size: fit-content !important;
   max-height: fit-content !important;
 }


### PR DESCRIPTION
Compatible with both old and new versions.
On the new version, the video takes a second longer to adjust and fill the entire area. There might be a way to make it faster but for now it works

fixes #1 